### PR TITLE
Implement two-way graphql relationship using @derivedFrom() directive 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,26 @@ Once you have built the subgraph and started a Graph Node you may open a GraphiQ
       whitelisted,
       deposit
     }
-    challengeId
   }
 }
 ```
 
 ```
 {
-  applications(first: 1000, where:{deposit_gt:"10000000000"}) {
+  applications(first: 100,
+    where: {
+        deposit_gt: "10000000000",
+        owner_in: ["0x7609e21921c7efcf73a588833bf7709889291781", "0x1a5cdcfba600e0c669795e0b65c344d5a37a4d5a"]
+   }) {
     id
     whitelisted
     deposit
+    owner
+    challenges {
+      id
+      outcome
+      rewardPool
+    }
   }
 }
 ```

--- a/mappings/ad-networks.ts
+++ b/mappings/ad-networks.ts
@@ -62,8 +62,7 @@ export function challenge(event: _Challenge): void {
 
   // Create challenge entity
   let challenge = new Entity()
-  challenge.setString('id', listingHash)
-  challenge.setU256('challengeId', challengeId)
+  challenge.setU256('id', challengeId)
   challenge.setU256('commitEndDate', commitEndDate)
   challenge.setU256('revealEndDate', revealEndDate)
   challenge.setAddress('challenger', challenger)
@@ -78,18 +77,18 @@ export function challenge(event: _Challenge): void {
 // Respond to challenge succeeded events
 export function challengeSucceeded(event: _ChallengeSucceeded): void {
   // Get param data from challenge succeeded event
-  let challengeHash = event.params.listingHash.toHex()
+  let listingHash = event.params.listingHash.toHex()
   let challengeId = event.params.challengeID
   let rewardPool = event.params.rewardPool
   let totalTokens = event.params.totalTokens
 
   // Create success entity
   let success = new Entity()
-  success.setString('id', challengeHash)
-  success.setU256('challengeId', challengeId)
+  success.setU256('id', challengeId)
   success.setU256('rewardPool', rewardPool)
   success.setU256('totalTokens', totalTokens)
   success.setString('outcome', 'success')
+  success.setString('application', listingHash)
 
   // Apply store updates
   let store = Store.bind(event.blockHash)
@@ -99,18 +98,19 @@ export function challengeSucceeded(event: _ChallengeSucceeded): void {
 // Respond to challenge failed events
 export function challengeFailed(event: _ChallengeFailed): void {
   // Get param data from challenge succeeded event
-  let challengeHash = event.params.listingHash.toHex()
+  let listingHash = event.params.listingHash.toHex()
   let challengeId = event.params.challengeID
   let rewardPool = event.params.rewardPool
   let totalTokens = event.params.totalTokens
 
   // Create fail entity
   let fail = new Entity()
-  fail.setString('id', challengeHash)
-  fail.setU256('challengeId', challengeId)
+  // fail.setString('id', challengeHash)
+  fail.setU256('id', challengeId)
   fail.setU256('rewardPool', rewardPool)
   fail.setU256('totalTokens', totalTokens)
   fail.setString('outcome', 'failed')
+  fail.setString('application', listingHash)
 
   // Apply store updates
   let store = Store.bind(event.blockHash)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,10 +1,10 @@
 type Application {
-    id: ID!
-    whitelisted: Boolean
-    expirationDate: String
-    owner: Bytes
-    deposit: BigInt
-    challenges: [Challenge] @derivedFrom(field: "application")
+  id: ID!
+  whitelisted: Boolean
+  expirationDate: String
+  owner: Bytes
+  deposit: BigInt
+  challenges: [Challenge] @derivedFrom(field: "application")
 }
 
 type Challenge {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,9 +1,10 @@
 type Application {
-  id: ID!
-  whitelisted: Boolean
-  expirationDate: String
-  owner: Bytes
-  deposit: BigInt
+    id: ID!
+    whitelisted: Boolean
+    expirationDate: String
+    owner: Bytes
+    deposit: BigInt
+    challenges: [Challenge] @derivedFrom(field: "application")
 }
 
 type Challenge {

--- a/schema.graphql
+++ b/schema.graphql
@@ -8,7 +8,6 @@ type Application {
 
 type Challenge {
   id: ID!
-  challengeId: BigInt
   application: Application
   commitEndDate: BigInt!
   revealEndDate: BigInt!


### PR DESCRIPTION
Closes graphprotocol/graph-node#232

In order to implement the two-way relationship between `Challenge` and `Application` the `Challenge` type was updated to use `challengeId` as the primary ID rather than `listingHash` allowing for unique Challenges to be brought into the Application type using the @derivedFrom directive.  Also updated was the handling of `ChallengeRemoved` and `ChallengeSucceeded` events which now set the `application` field to ensure the reference is maintained as the `Challenge` entity is created and updated. 