### PR TITLE
Update to graph-ts, reorganize source tree a little bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adchain",
   "scripts": {
-    "codegen": "graph codegen --output-dir=src subgraph.yaml",
+    "codegen": "graph codegen --output-dir=src/abis/ subgraph.yaml",
     "build": "graph build subgraph.yaml",
     "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001 subgraph.yaml",
     "build-wast": "graph build -t wast subgraph.yaml",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "adchain",
   "scripts": {
-    "codegen": "graph codegen subgraph.yaml",
+    "codegen": "graph codegen --output-dir=src subgraph.yaml",
     "build": "graph build subgraph.yaml",
     "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001 subgraph.yaml",
-    "build-wast": "graph build -t wast subgraph.yaml"
+    "build-wast": "graph build -t wast subgraph.yaml",
+    "deploy": "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1:8020 -n adchain subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.2.8"
+    "@graphprotocol/graph-cli": "^0.2.8",
+    "@graphprotocol/graph-ts": "^0.0.1"
   }
 }

--- a/src/AdNetworks/Registry.ts
+++ b/src/AdNetworks/Registry.ts
@@ -1,0 +1,494 @@
+import {
+  EthereumEvent,
+  SmartContract,
+  EthereumValue,
+  JSONValue,
+  TypedMap,
+  Entity,
+  Bytes,
+  Address,
+  I128,
+  U128,
+  I256,
+  U256,
+  H256
+} from "@graphprotocol/graph-ts";
+
+export class _Application extends EthereumEvent {
+  get params(): _ApplicationParams {
+    return new _ApplicationParams(this);
+  }
+}
+
+export class _ApplicationParams {
+  _event: _Application;
+
+  constructor(event: _Application) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get deposit(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get appEndDate(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get data(): string {
+    return this._event.parameters[3].value.toString();
+  }
+
+  get applicant(): Address {
+    return this._event.parameters[4].value.toAddress();
+  }
+}
+
+export class _Challenge extends EthereumEvent {
+  get params(): _ChallengeParams {
+    return new _ChallengeParams(this);
+  }
+}
+
+export class _ChallengeParams {
+  _event: _Challenge;
+
+  constructor(event: _Challenge) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get data(): string {
+    return this._event.parameters[2].value.toString();
+  }
+
+  get commitEndDate(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+
+  get revealEndDate(): U256 {
+    return this._event.parameters[4].value.toU256();
+  }
+
+  get challenger(): Address {
+    return this._event.parameters[5].value.toAddress();
+  }
+}
+
+export class _Deposit extends EthereumEvent {
+  get params(): _DepositParams {
+    return new _DepositParams(this);
+  }
+}
+
+export class _DepositParams {
+  _event: _Deposit;
+
+  constructor(event: _Deposit) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get added(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get newTotal(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get owner(): Address {
+    return this._event.parameters[3].value.toAddress();
+  }
+}
+
+export class _Withdrawal extends EthereumEvent {
+  get params(): _WithdrawalParams {
+    return new _WithdrawalParams(this);
+  }
+}
+
+export class _WithdrawalParams {
+  _event: _Withdrawal;
+
+  constructor(event: _Withdrawal) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get withdrew(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get newTotal(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get owner(): Address {
+    return this._event.parameters[3].value.toAddress();
+  }
+}
+
+export class _ApplicationWhitelisted extends EthereumEvent {
+  get params(): _ApplicationWhitelistedParams {
+    return new _ApplicationWhitelistedParams(this);
+  }
+}
+
+export class _ApplicationWhitelistedParams {
+  _event: _ApplicationWhitelisted;
+
+  constructor(event: _ApplicationWhitelisted) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ApplicationRemoved extends EthereumEvent {
+  get params(): _ApplicationRemovedParams {
+    return new _ApplicationRemovedParams(this);
+  }
+}
+
+export class _ApplicationRemovedParams {
+  _event: _ApplicationRemoved;
+
+  constructor(event: _ApplicationRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ListingRemoved extends EthereumEvent {
+  get params(): _ListingRemovedParams {
+    return new _ListingRemovedParams(this);
+  }
+}
+
+export class _ListingRemovedParams {
+  _event: _ListingRemoved;
+
+  constructor(event: _ListingRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ListingWithdrawn extends EthereumEvent {
+  get params(): _ListingWithdrawnParams {
+    return new _ListingWithdrawnParams(this);
+  }
+}
+
+export class _ListingWithdrawnParams {
+  _event: _ListingWithdrawn;
+
+  constructor(event: _ListingWithdrawn) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _TouchAndRemoved extends EthereumEvent {
+  get params(): _TouchAndRemovedParams {
+    return new _TouchAndRemovedParams(this);
+  }
+}
+
+export class _TouchAndRemovedParams {
+  _event: _TouchAndRemoved;
+
+  constructor(event: _TouchAndRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ChallengeFailed extends EthereumEvent {
+  get params(): _ChallengeFailedParams {
+    return new _ChallengeFailedParams(this);
+  }
+}
+
+export class _ChallengeFailedParams {
+  _event: _ChallengeFailed;
+
+  constructor(event: _ChallengeFailed) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get rewardPool(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get totalTokens(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+}
+
+export class _ChallengeSucceeded extends EthereumEvent {
+  get params(): _ChallengeSucceededParams {
+    return new _ChallengeSucceededParams(this);
+  }
+}
+
+export class _ChallengeSucceededParams {
+  _event: _ChallengeSucceeded;
+
+  constructor(event: _ChallengeSucceeded) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get rewardPool(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get totalTokens(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+}
+
+export class _RewardClaimed extends EthereumEvent {
+  get params(): _RewardClaimedParams {
+    return new _RewardClaimedParams(this);
+  }
+}
+
+export class _RewardClaimedParams {
+  _event: _RewardClaimed;
+
+  constructor(event: _RewardClaimed) {
+    this._event = event;
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[0].value.toU256();
+  }
+
+  get reward(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get voter(): Address {
+    return this._event.parameters[2].value.toAddress();
+  }
+}
+
+export class Registry__challengesResult {
+  value0: U256;
+  value1: Address;
+  value2: boolean;
+  value3: U256;
+  value4: U256;
+
+  constructor(
+    value0: U256,
+    value1: Address,
+    value2: boolean,
+    value3: U256,
+    value4: U256
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+  }
+
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromAddress(this.value1));
+    map.set("value2", EthereumValue.fromBoolean(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    return map;
+  }
+}
+
+export class Registry__listingsResult {
+  value0: U256;
+  value1: boolean;
+  value2: Address;
+  value3: U256;
+  value4: U256;
+
+  constructor(
+    value0: U256,
+    value1: boolean,
+    value2: Address,
+    value3: U256,
+    value4: U256
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+  }
+
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromBoolean(this.value1));
+    map.set("value2", EthereumValue.fromAddress(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    return map;
+  }
+}
+
+export class Registry extends SmartContract {
+  static bind(address: Address): Registry {
+    return new Registry("Registry", address);
+  }
+
+  isWhitelisted(_listingHash: Bytes): boolean {
+    let result = super.call("isWhitelisted", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  name(): string {
+    let result = super.call("name", []);
+    return result[0].toString();
+  }
+
+  challengeExists(_listingHash: Bytes): boolean {
+    let result = super.call("challengeExists", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  canBeWhitelisted(_listingHash: Bytes): boolean {
+    let result = super.call("canBeWhitelisted", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  challengeCanBeResolved(_listingHash: Bytes): boolean {
+    let result = super.call("challengeCanBeResolved", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  appWasMade(_listingHash: Bytes): boolean {
+    let result = super.call("appWasMade", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  challenges(param0: U256): Registry__challengesResult {
+    let result = super.call("challenges", [EthereumValue.fromU256(param0)]);
+    return new Registry__challengesResult(
+      result[0].toU256(),
+      result[1].toAddress(),
+      result[2].toBoolean(),
+      result[3].toU256(),
+      result[4].toU256()
+    );
+  }
+
+  tokenClaims(_challengeID: U256, _voter: Address): boolean {
+    let result = super.call("tokenClaims", [
+      EthereumValue.fromU256(_challengeID),
+      EthereumValue.fromAddress(_voter)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  voterReward(_voter: Address, _challengeID: U256, _salt: U256): U256 {
+    let result = super.call("voterReward", [
+      EthereumValue.fromAddress(_voter),
+      EthereumValue.fromU256(_challengeID),
+      EthereumValue.fromU256(_salt)
+    ]);
+    return result[0].toU256();
+  }
+
+  listings(param0: Bytes): Registry__listingsResult {
+    let result = super.call("listings", [EthereumValue.fromFixedBytes(param0)]);
+    return new Registry__listingsResult(
+      result[0].toU256(),
+      result[1].toBoolean(),
+      result[2].toAddress(),
+      result[3].toU256(),
+      result[4].toU256()
+    );
+  }
+
+  determineReward(_challengeID: U256): U256 {
+    let result = super.call("determineReward", [
+      EthereumValue.fromU256(_challengeID)
+    ]);
+    return result[0].toU256();
+  }
+
+  parameterizer(): Address {
+    let result = super.call("parameterizer", []);
+    return result[0].toAddress();
+  }
+
+  token(): Address {
+    let result = super.call("token", []);
+    return result[0].toAddress();
+  }
+
+  voting(): Address {
+    let result = super.call("voting", []);
+    return result[0].toAddress();
+  }
+}

--- a/src/abis/AdNetworks/Registry.ts
+++ b/src/abis/AdNetworks/Registry.ts
@@ -1,0 +1,494 @@
+import {
+  EthereumEvent,
+  SmartContract,
+  EthereumValue,
+  JSONValue,
+  TypedMap,
+  Entity,
+  Bytes,
+  Address,
+  I128,
+  U128,
+  I256,
+  U256,
+  H256
+} from "@graphprotocol/graph-ts";
+
+export class _Application extends EthereumEvent {
+  get params(): _ApplicationParams {
+    return new _ApplicationParams(this);
+  }
+}
+
+export class _ApplicationParams {
+  _event: _Application;
+
+  constructor(event: _Application) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get deposit(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get appEndDate(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get data(): string {
+    return this._event.parameters[3].value.toString();
+  }
+
+  get applicant(): Address {
+    return this._event.parameters[4].value.toAddress();
+  }
+}
+
+export class _Challenge extends EthereumEvent {
+  get params(): _ChallengeParams {
+    return new _ChallengeParams(this);
+  }
+}
+
+export class _ChallengeParams {
+  _event: _Challenge;
+
+  constructor(event: _Challenge) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get data(): string {
+    return this._event.parameters[2].value.toString();
+  }
+
+  get commitEndDate(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+
+  get revealEndDate(): U256 {
+    return this._event.parameters[4].value.toU256();
+  }
+
+  get challenger(): Address {
+    return this._event.parameters[5].value.toAddress();
+  }
+}
+
+export class _Deposit extends EthereumEvent {
+  get params(): _DepositParams {
+    return new _DepositParams(this);
+  }
+}
+
+export class _DepositParams {
+  _event: _Deposit;
+
+  constructor(event: _Deposit) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get added(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get newTotal(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get owner(): Address {
+    return this._event.parameters[3].value.toAddress();
+  }
+}
+
+export class _Withdrawal extends EthereumEvent {
+  get params(): _WithdrawalParams {
+    return new _WithdrawalParams(this);
+  }
+}
+
+export class _WithdrawalParams {
+  _event: _Withdrawal;
+
+  constructor(event: _Withdrawal) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get withdrew(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get newTotal(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get owner(): Address {
+    return this._event.parameters[3].value.toAddress();
+  }
+}
+
+export class _ApplicationWhitelisted extends EthereumEvent {
+  get params(): _ApplicationWhitelistedParams {
+    return new _ApplicationWhitelistedParams(this);
+  }
+}
+
+export class _ApplicationWhitelistedParams {
+  _event: _ApplicationWhitelisted;
+
+  constructor(event: _ApplicationWhitelisted) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ApplicationRemoved extends EthereumEvent {
+  get params(): _ApplicationRemovedParams {
+    return new _ApplicationRemovedParams(this);
+  }
+}
+
+export class _ApplicationRemovedParams {
+  _event: _ApplicationRemoved;
+
+  constructor(event: _ApplicationRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ListingRemoved extends EthereumEvent {
+  get params(): _ListingRemovedParams {
+    return new _ListingRemovedParams(this);
+  }
+}
+
+export class _ListingRemovedParams {
+  _event: _ListingRemoved;
+
+  constructor(event: _ListingRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ListingWithdrawn extends EthereumEvent {
+  get params(): _ListingWithdrawnParams {
+    return new _ListingWithdrawnParams(this);
+  }
+}
+
+export class _ListingWithdrawnParams {
+  _event: _ListingWithdrawn;
+
+  constructor(event: _ListingWithdrawn) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _TouchAndRemoved extends EthereumEvent {
+  get params(): _TouchAndRemovedParams {
+    return new _TouchAndRemovedParams(this);
+  }
+}
+
+export class _TouchAndRemovedParams {
+  _event: _TouchAndRemoved;
+
+  constructor(event: _TouchAndRemoved) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+}
+
+export class _ChallengeFailed extends EthereumEvent {
+  get params(): _ChallengeFailedParams {
+    return new _ChallengeFailedParams(this);
+  }
+}
+
+export class _ChallengeFailedParams {
+  _event: _ChallengeFailed;
+
+  constructor(event: _ChallengeFailed) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get rewardPool(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get totalTokens(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+}
+
+export class _ChallengeSucceeded extends EthereumEvent {
+  get params(): _ChallengeSucceededParams {
+    return new _ChallengeSucceededParams(this);
+  }
+}
+
+export class _ChallengeSucceededParams {
+  _event: _ChallengeSucceeded;
+
+  constructor(event: _ChallengeSucceeded) {
+    this._event = event;
+  }
+
+  get listingHash(): Bytes {
+    return this._event.parameters[0].value.toBytes();
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get rewardPool(): U256 {
+    return this._event.parameters[2].value.toU256();
+  }
+
+  get totalTokens(): U256 {
+    return this._event.parameters[3].value.toU256();
+  }
+}
+
+export class _RewardClaimed extends EthereumEvent {
+  get params(): _RewardClaimedParams {
+    return new _RewardClaimedParams(this);
+  }
+}
+
+export class _RewardClaimedParams {
+  _event: _RewardClaimed;
+
+  constructor(event: _RewardClaimed) {
+    this._event = event;
+  }
+
+  get challengeID(): U256 {
+    return this._event.parameters[0].value.toU256();
+  }
+
+  get reward(): U256 {
+    return this._event.parameters[1].value.toU256();
+  }
+
+  get voter(): Address {
+    return this._event.parameters[2].value.toAddress();
+  }
+}
+
+export class Registry__challengesResult {
+  value0: U256;
+  value1: Address;
+  value2: boolean;
+  value3: U256;
+  value4: U256;
+
+  constructor(
+    value0: U256,
+    value1: Address,
+    value2: boolean,
+    value3: U256,
+    value4: U256
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+  }
+
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromAddress(this.value1));
+    map.set("value2", EthereumValue.fromBoolean(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    return map;
+  }
+}
+
+export class Registry__listingsResult {
+  value0: U256;
+  value1: boolean;
+  value2: Address;
+  value3: U256;
+  value4: U256;
+
+  constructor(
+    value0: U256,
+    value1: boolean,
+    value2: Address,
+    value3: U256,
+    value4: U256
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+  }
+
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromBoolean(this.value1));
+    map.set("value2", EthereumValue.fromAddress(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    return map;
+  }
+}
+
+export class Registry extends SmartContract {
+  static bind(address: Address): Registry {
+    return new Registry("Registry", address);
+  }
+
+  isWhitelisted(_listingHash: Bytes): boolean {
+    let result = super.call("isWhitelisted", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  name(): string {
+    let result = super.call("name", []);
+    return result[0].toString();
+  }
+
+  challengeExists(_listingHash: Bytes): boolean {
+    let result = super.call("challengeExists", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  canBeWhitelisted(_listingHash: Bytes): boolean {
+    let result = super.call("canBeWhitelisted", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  challengeCanBeResolved(_listingHash: Bytes): boolean {
+    let result = super.call("challengeCanBeResolved", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  appWasMade(_listingHash: Bytes): boolean {
+    let result = super.call("appWasMade", [
+      EthereumValue.fromFixedBytes(_listingHash)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  challenges(param0: U256): Registry__challengesResult {
+    let result = super.call("challenges", [EthereumValue.fromU256(param0)]);
+    return new Registry__challengesResult(
+      result[0].toU256(),
+      result[1].toAddress(),
+      result[2].toBoolean(),
+      result[3].toU256(),
+      result[4].toU256()
+    );
+  }
+
+  tokenClaims(_challengeID: U256, _voter: Address): boolean {
+    let result = super.call("tokenClaims", [
+      EthereumValue.fromU256(_challengeID),
+      EthereumValue.fromAddress(_voter)
+    ]);
+    return result[0].toBoolean();
+  }
+
+  voterReward(_voter: Address, _challengeID: U256, _salt: U256): U256 {
+    let result = super.call("voterReward", [
+      EthereumValue.fromAddress(_voter),
+      EthereumValue.fromU256(_challengeID),
+      EthereumValue.fromU256(_salt)
+    ]);
+    return result[0].toU256();
+  }
+
+  listings(param0: Bytes): Registry__listingsResult {
+    let result = super.call("listings", [EthereumValue.fromFixedBytes(param0)]);
+    return new Registry__listingsResult(
+      result[0].toU256(),
+      result[1].toBoolean(),
+      result[2].toAddress(),
+      result[3].toU256(),
+      result[4].toU256()
+    );
+  }
+
+  determineReward(_challengeID: U256): U256 {
+    let result = super.call("determineReward", [
+      EthereumValue.fromU256(_challengeID)
+    ]);
+    return result[0].toU256();
+  }
+
+  parameterizer(): Address {
+    let result = super.call("parameterizer", []);
+    return result[0].toAddress();
+  }
+
+  token(): Address {
+    let result = super.call("token", []);
+    return result[0].toAddress();
+  }
+
+  voting(): Address {
+    let result = super.call("voting", []);
+    return result[0].toAddress();
+  }
+}

--- a/src/ad-networks.ts
+++ b/src/ad-networks.ts
@@ -1,0 +1,221 @@
+import { Entity, store } from '@graphprotocol/graph-ts'
+import {
+  _Application,
+  _ApplicationRemoved,
+  _ApplicationWhitelisted,
+  _Challenge,
+  _ChallengeFailed,
+  _ChallengeSucceeded,
+  _Deposit,
+  _ListingRemoved,
+  _ListingWithdrawn,
+  _RewardClaimed,
+  _Withdrawal,
+  Registry,
+} from './abis/AdNetworks/Registry'
+
+// Respond to application white listed events
+export function applicationWhitelist(event: _ApplicationWhitelisted): void {
+  let listingHash = event.params.listingHash.toHex()
+
+  // Bind registry contract
+  let registry = Registry.bind(event.address)
+
+  // Use listings method to get application data
+  let listingResult = registry.listings(event.params.listingHash)
+
+  // Create application entity
+  let application = new Entity()
+  application.setString('id', listingHash)
+  application.setBoolean('whitelisted', true)
+  application.setU256('expirationDate', listingResult.value0)
+  application.setBoolean('whitelisted', listingResult.value1)
+  application.setAddress('owner', listingResult.value2)
+  application.setU256('deposit', listingResult.value3)
+
+  let user = new Entity()
+  user.setAddress('address', listingResult.value2)
+
+  // Apply store updates (insert or update if entity already exists)
+  store.set('Application', listingHash, application)
+  store.set('User', listingResult.value2.toHex(), user)
+}
+
+// Respond to application removed events
+export function applicationRemoved(event: _ApplicationRemoved): void {
+  let listingHash = event.params.listingHash.toHex()
+
+  // Remove application from the store
+  store.remove('Application', listingHash)
+}
+
+// Respond to application added events
+export function applicationAdded(event: _Application): void {
+  // Get param data from application event
+  let appHash = event.params.listingHash.toHex()
+  let appDeposit = event.params.deposit
+  let appApplicant = event.params.applicant
+  let appEndDate = event.params.appEndDate
+
+  // Create application entity
+  let application = new Entity()
+  application.setString('id', appHash)
+  application.setU256('deposit', appDeposit)
+  application.setAddress('applicant', appApplicant)
+  application.setU256('endDate', appEndDate)
+  application.setBoolean('whitelisted', false)
+
+  // Apply store updates
+  store.set('Application', appHash, application)
+}
+
+// Respond to challange submitted events
+export function challenge(event: _Challenge): void {
+  // Get param data from challenge event
+  let listingHash = event.params.listingHash.toHex()
+  let challengeId = event.params.challengeID
+  let commitEndDate = event.params.commitEndDate
+  let revealEndDate = event.params.revealEndDate
+  let challenger = event.params.challenger
+
+  // Create challenge entity
+  let challenge = new Entity()
+  challenge.setU256('id', challengeId)
+  challenge.setU256('commitEndDate', commitEndDate)
+  challenge.setU256('revealEndDate', revealEndDate)
+  challenge.setAddress('challenger', challenger)
+  challenge.setString('application', listingHash)
+  challenge.setString('outcome', 'pending')
+  challenge.setBoolean('rewardClaimed', false)
+
+  let user = new Entity()
+  user.setAddress('address', challenger)
+
+  // Apply store updates
+  store.set('Challenge', challengeId.toHex(), challenge)
+}
+
+// Respond to challenge succeeded events
+export function challengeSucceeded(event: _ChallengeSucceeded): void {
+  // Get param data from challenge succeeded event
+  let listingHash = event.params.listingHash.toHex()
+  let challengeId = event.params.challengeID
+  let rewardPool = event.params.rewardPool
+  let totalTokens = event.params.totalTokens
+
+  // Create success entity
+  let success = new Entity()
+  success.setU256('id', challengeId)
+  success.setU256('rewardPool', rewardPool)
+  success.setU256('totalTokens', totalTokens)
+  success.setString('outcome', 'success')
+  success.setString('application', listingHash)
+
+  // Apply store updates
+  store.set('Challenge', challengeId.toHex(), success)
+}
+
+// Respond to challenge failed events
+export function challengeFailed(event: _ChallengeFailed): void {
+  // Get param data from challenge succeeded event
+  let listingHash = event.params.listingHash.toHex()
+  let challengeId = event.params.challengeID
+  let rewardPool = event.params.rewardPool
+  let totalTokens = event.params.totalTokens
+
+  // Create fail entity
+  let fail = new Entity()
+  fail.setU256('id', challengeId)
+  fail.setU256('rewardPool', rewardPool)
+  fail.setU256('totalTokens', totalTokens)
+  fail.setString('outcome', 'failed')
+  fail.setString('application', listingHash)
+
+  // Apply store updates
+  store.set('Challenge', challengeId.toHex(), fail)
+}
+
+// Respond to deposit events
+export function deposit(event: _Deposit): void {
+  // Get param data from deposit event
+  let listingHash = event.params.listingHash.toHex()
+  let added = event.params.added
+  let newTotal = event.params.newTotal
+  let owner = event.params.owner
+  let depositId = listingHash + '_' + owner.toHex()
+
+  // Create fail entity
+  let deposit = new Entity()
+  deposit.setString('id', depositId)
+  deposit.setU256('added', added)
+  deposit.setU256('newTotal', newTotal)
+  deposit.setString('owner', owner.toHex())
+
+  let user = new Entity()
+  user.setAddress('address', owner)
+
+  // Apply store updates
+  store.set('Challenge', depositId, deposit)
+  store.set('User', owner.toHex(), user)
+}
+
+// Respond to withdrawal events
+export function withdrawal(event: _Withdrawal): void {
+  // Get param data from withdrawal event
+  let listingHash = event.params.listingHash.toHex()
+  let withdrew = event.params.withdrew
+  let newTotal = event.params.newTotal
+  let owner = event.params.owner
+  let withdrawId = listingHash + '_' + owner.toHex()
+
+  // Create fail entity
+  let withdrawal = new Entity()
+  withdrawal.setString('id', withdrawId)
+  withdrawal.setU256('withdrew', withdrew)
+  withdrawal.setU256('newTotal', newTotal)
+  withdrawal.setString('owner', owner.toHex())
+
+  let user = new Entity()
+  user.setAddress('address', owner)
+
+  // Apply store updates
+  store.set('Withdrawal', withdrawId, withdrawal)
+  store.set('User', owner.toHex(), user)
+}
+
+// Respond to listing removed events
+export function listingRemoved(event: _ListingRemoved): void {
+  // Get param data from listing removed event
+  let listingHash = event.params.listingHash.toHex()
+
+  // Apply store updates
+  store.remove('Application', listingHash)
+}
+
+// Respond to listing withdrawn events
+export function listingWithdrawn(event: _ListingWithdrawn): void {
+  // Get param data from listingWithdrawn event
+  let listingHash = event.params.listingHash.toHex()
+
+  // Apply store updates
+  store.remove('Application', listingHash)
+}
+
+// Respond to reward claimed events
+export function rewardClaimed(event: _RewardClaimed): void {
+  // Get param data from rewardClaimed event
+  let challengeId = event.params.challengeID
+  let voter = event.params.voter
+
+  // Create challenge reward entity
+  let challengeReward = new Entity()
+  challengeReward.setAddress('voter', voter)
+  challengeReward.setBoolean('rewardClaimed', true)
+
+  let user = new Entity()
+  user.setAddress('address', voter)
+
+  // Apply store updates
+  store.set('Challenge', challengeId.toHex(), challengeReward)
+  store.set('User', voter.toHex(), user)
+}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -2,43 +2,43 @@ specVersion: 0.0.1
 schema:
   file: ./schema.graphql
 dataSources:
-- kind: ethereum/contract
-  name: AdNetworks
-  source:
-    address: "5E2Eb68A31229B469e34999C467b017222677183"
-    abi: Registry
-  mapping:
-    kind: ethereum/events
-    apiVersion: 0.0.1
-    language: wasm/assemblyscript
-    file: ./mappings/ad-networks.ts
-    entities:
-    - Application
-    - Challenge
-    - Deposit
-    - Withdrawal
-    - User
-    abis:
-    - name: Registry
-      file: ./abis/adNetworks.json
-    eventHandlers:
-    - event: _ApplicationWhitelisted(bytes32)
-      handler: applicationWhitelist
-    - event: _ApplicationRemoved(bytes32)
-      handler: applicationRemoved
-    - event: _Challenge(bytes32,uint256,string,uint256,uint256,address)
-      handler: challenge
-    - event: _ChallengeSucceeded(bytes32,uint256,uint256,uint256)
-      handler: challengeSucceeded
-    - event: _ChallengeFailed(bytes32,uint256,uint256,uint256)
-      handler: challengeFailed
-    - event: _Deposit(bytes32,uint256,uint256,address)
-      handler: deposit
-    - event: _Withdrawal(bytes32,uint256,uint256,address)
-      handler: withdrawal
-    - event: _ListingRemoved(bytes32)
-      handler: listingRemoved
-    - event: _ListingWithdrawn(bytes32)
-      handler: listingWithdrawn
-    - event: _RewardClaimed(uint256, uint256, address)
-      handler: rewardClaimed
+  - kind: ethereum/contract
+    name: AdNetworks
+    source:
+      address: '0x5E2Eb68A31229B469e34999C467b017222677183'
+      abi: Registry
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./src/ad-networks.ts
+      entities:
+        - Application
+        - Challenge
+        - Deposit
+        - Withdrawal
+        - User
+      abis:
+        - name: Registry
+          file: ./abis/adNetworks.json
+      eventHandlers:
+        - event: _ApplicationWhitelisted(bytes32)
+          handler: applicationWhitelist
+        - event: _ApplicationRemoved(bytes32)
+          handler: applicationRemoved
+        - event: _Challenge(bytes32,uint256,string,uint256,uint256,address)
+          handler: challenge
+        - event: _ChallengeSucceeded(bytes32,uint256,uint256,uint256)
+          handler: challengeSucceeded
+        - event: _ChallengeFailed(bytes32,uint256,uint256,uint256)
+          handler: challengeFailed
+        - event: _Deposit(bytes32,uint256,uint256,address)
+          handler: deposit
+        - event: _Withdrawal(bytes32,uint256,uint256,address)
+          handler: withdrawal
+        - event: _ListingRemoved(bytes32)
+          handler: listingRemoved
+        - event: _ListingWithdrawn(bytes32)
+          handler: listingWithdrawn
+        - event: _RewardClaimed(uint256, uint256, address)
+          handler: rewardClaimed

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@graphprotocol/graph-cli@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.2.8.tgz#69d3cc277269cf5db88a7ff5b70097381daf9171"
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.2.9.tgz#d2c3e6f2f2eacadb8aa567a2fd55c9a8c6fbb954"
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#c4ebc8c291c1068da73ddf1a381eab93e1f69e11"
     chalk "^2.4.1"
@@ -20,6 +20,12 @@
     prettier "^1.13.5"
     request "^2.88.0"
     winston "^3.0.0"
+
+"@graphprotocol/graph-ts@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.0.1.tgz#4a515bb68ab14e6caf70cf154010c357ddb19db9"
+  dependencies:
+    assemblyscript "^0.3.0"
 
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
@@ -122,6 +128,15 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assemblyscript@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.3.0.tgz#58d1eb6777c02176b19f55197bb35419384c088f"
+  dependencies:
+    binaryen "37.0.0-nightly.20170909"
+    chalk "^2.1.0"
+    minimist "^1.2.0"
+    wabt "0.0.13-nightly.20170628"
+
 "assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#c4ebc8c291c1068da73ddf1a381eab93e1f69e11":
   version "0.5.0"
   resolved "git+https://github.com/AssemblyScript/assemblyscript.git#c4ebc8c291c1068da73ddf1a381eab93e1f69e11"
@@ -204,6 +219,10 @@ binary-extensions@^1.0.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
 
+binaryen@37.0.0-nightly.20170909:
+  version "37.0.0-nightly.20170909"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-37.0.0-nightly.20170909.tgz#2e9731249ef33d5813d530572cfe55838caa75df"
+
 binaryen@48.0.0-nightly.20180627:
   version "48.0.0-nightly.20180627"
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-48.0.0-nightly.20180627.tgz#605e42c7db752922560d7f2582d5c9dcaa2f4822"
@@ -274,7 +293,7 @@ brorand@^1.0.1:
 
 browserify-aes@^1.0.6, browserify-aes@^1.1.1, browserify-aes@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  resolved "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -293,7 +312,7 @@ buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
 
-buffer-alloc@^1.1.0:
+buffer-alloc@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
   dependencies:
@@ -307,10 +326,6 @@ buffer-fill@^1.0.0:
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-
-buffer-loader@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-loader/-/buffer-loader-0.0.1.tgz#4d677ca92dd889310878b02a2fbcfab712024cf2"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -338,7 +353,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^2.4.1:
+chalk@^2.1.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -369,13 +384,14 @@ chownr@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
-cids@0.5.3, cids@^0.5.3, cids@~0.5.2, cids@~0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.3.tgz#9a25b697eb76faf807afcec35c4ab936edfbd0a4"
+cids@^0.5.3, cids@~0.5.2, cids@~0.5.3, cids@~0.5.4, cids@~0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.5.tgz#03fffeccdac2bf82c5b6334a563b0b87858eb841"
   dependencies:
-    multibase "~0.4.0"
-    multicodec "~0.2.6"
-    multihashes "~0.4.13"
+    class-is "^1.1.0"
+    multibase "~0.5.0"
+    multicodec "~0.2.7"
+    multihashes "~0.4.14"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -386,7 +402,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 
 class-is@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
+  resolved "http://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -413,18 +429,18 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 color-convert@^1.9.0, color-convert@^1.9.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   dependencies:
-    color-name "1.1.1"
+    color-name "1.1.3"
 
-color-name@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
-
-color-name@^1.0.0:
+color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
 
 color-string@^1.5.2:
   version "1.5.3"
@@ -445,8 +461,8 @@ colornames@^1.1.1:
   resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
 
 colors@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.1.tgz#4accdb89cf2cabc7f982771925e9468784f32f3d"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
 
 colorspace@1.1.x:
   version "1.1.1"
@@ -467,13 +483,9 @@ combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.2:
+commander@^2.12.2, commander@^2.15.0, commander@^2.15.1:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
-
-commander@^2.15.0, commander@^2.15.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -506,7 +518,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  resolved "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
@@ -516,7 +528,7 @@ create-hash@^1.1.0, create-hash@^1.1.2:
 
 create-hmac@^1.1.4:
   version "1.1.7"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  resolved "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -538,10 +550,10 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
   dependencies:
-    ms "2.0.0"
+    ms "^2.1.1"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -587,10 +599,10 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 detect-node@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
 
-diagnostics@^1.0.1:
+diagnostics@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.1.tgz#cab6ac33df70c9d9a727490ae43ac995a769b22a"
   dependencies:
@@ -830,20 +842,9 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.5:
+glob@^7.0.5, glob@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1051,18 +1052,17 @@ ipld-dag-cbor@~0.12.1:
     traverse "~0.6.6"
 
 ipld-dag-pb@~0.14.6:
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.14.8.tgz#6142f8535928d4c8e935cde629f9a53eed0b20f0"
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.14.10.tgz#dc9f249da949337682d26263e47578b0ebb51896"
   dependencies:
     async "^2.6.1"
     bs58 "^4.0.1"
-    buffer-loader "~0.0.1"
-    cids "~0.5.3"
+    cids "~0.5.4"
     class-is "^1.1.0"
     is-ipfs "~0.4.2"
     multihashing-async "~0.5.1"
     protons "^1.0.1"
-    pull-stream "^3.6.8"
+    pull-stream "^3.6.9"
     pull-traverse "^1.0.3"
     stable "~0.1.8"
 
@@ -1161,13 +1161,13 @@ is-glob@^4.0.0:
     is-extglob "^2.1.1"
 
 is-ipfs@~0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.4.2.tgz#06a858769cbfdac39a3e0ed1ca157e3f3fcc84fc"
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.4.7.tgz#748616ccfccc96601d4fb87aae1830cf8c5b9d62"
   dependencies:
     bs58 "4.0.1"
-    cids "0.5.3"
-    multibase "0.4.0"
-    multihashes "0.4.13"
+    cids "~0.5.5"
+    multibase "~0.4.0"
+    multihashes "~0.4.13"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -1329,7 +1329,7 @@ libp2p-crypto-secp256k1@~0.2.2:
 
 libp2p-crypto@~0.12.1:
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz#4a870d269ba3150dfe014e4f9aea1e55076015c8"
+  resolved "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz#4a870d269ba3150dfe014e4f9aea1e55076015c8"
   dependencies:
     asn1.js "^5.0.0"
     async "^2.6.0"
@@ -1347,7 +1347,7 @@ libp2p-crypto@~0.12.1:
 
 libp2p-crypto@~0.13.0:
   version "0.13.0"
-  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz#25404ea43bf2fd3802780d9ab87b5d2095d86f07"
+  resolved "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz#25404ea43bf2fd3802780d9ab87b5d2095d86f07"
   dependencies:
     asn1.js "^5.0.0"
     async "^2.6.0"
@@ -1399,17 +1399,13 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
-lodash@^4.17.10, lodash@^4.17.5:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
-lodash@^4.17.4:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-logform@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-1.9.1.tgz#58b29d7b11c332456d7a217e17b48a13ad69d60a"
+logform@^1.9.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-1.10.0.tgz#c9d5598714c92b546e23f4e78147c40f1e02012e"
   dependencies:
     colors "^1.2.1"
     fast-safe-stringify "^2.0.4"
@@ -1433,10 +1429,10 @@ lru-cache@^4.1.3:
     yallist "^2.1.2"
 
 mafmt@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.0.tgz#ec13f8761253354c23420ae3903c837b6649caa6"
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.2.tgz#236f08e35d37c4efd96f869ade919b71f5972992"
   dependencies:
-    multiaddr "^4.0.0"
+    multiaddr "^5.0.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -1503,7 +1499,7 @@ minimist@0.0.8:
 
 minimist@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 minipass@^2.2.1, minipass@^2.3.3:
   version "2.3.4"
@@ -1565,26 +1561,25 @@ multiaddr@^5.0.0:
     varint "^5.0.0"
     xtend "^4.0.1"
 
-multibase@0.4.0, multibase@~0.4.0:
+multibase@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.4.0.tgz#1bdb62c82de0114f822a1d8751bcbee91cd2efba"
   dependencies:
     base-x "3.0.4"
 
-multicodec@~0.2.6:
+multibase@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.5.0.tgz#45668ad138963d778bdf1f79da64f21caa7bb6eb"
+  dependencies:
+    base-x "3.0.4"
+
+multicodec@~0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.2.7.tgz#44dcb902b7ccd8065c4c348fe9987acf14a0679d"
   dependencies:
     varint "^5.0.0"
 
-multihashes@0.4.13:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.13.tgz#d10bd71bd51d24aa894e2a6f1457146bb7bac125"
-  dependencies:
-    bs58 "^4.0.1"
-    varint "^5.0.0"
-
-multihashes@~0.4.12, multihashes@~0.4.13:
+multihashes@~0.4.12, multihashes@~0.4.13, multihashes@~0.4.14:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.14.tgz#774db9a161f81a8a27dc60788f91248e020f5244"
   dependencies:
@@ -1617,13 +1612,9 @@ murmurhash3js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
 
-nan@^2.2.1:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-
-nan@^2.9.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+nan@^2.2.1, nan@^2.9.2:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -1651,8 +1642,8 @@ ndjson@^1.5.0:
     through2 "^2.0.3"
 
 needle@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.3.tgz#c1b04da378cd634d8befe2de965dc2cfb0fd65ca"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -1838,8 +1829,8 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
 prettier@^1.13.5:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
@@ -1847,7 +1838,7 @@ process-nextick-args@~2.0.0:
 
 promise@~1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-1.3.0.tgz#e5cc9a4c8278e4664ffedc01c7da84842b040175"
+  resolved "http://registry.npmjs.org/promise/-/promise-1.3.0.tgz#e5cc9a4c8278e4664ffedc01c7da84842b040175"
   dependencies:
     is-promise "~1"
 
@@ -1888,9 +1879,9 @@ pull-stream-to-stream@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz#3f81d8216bd18d2bfd1a198190471180e2738399"
 
-pull-stream@^3.2.3, pull-stream@^3.6.8:
-  version "3.6.8"
-  resolved "https://registry.yarnpkg.com/pull-stream/-/pull-stream-3.6.8.tgz#d63dee1c55ff2023fd380f724c387e931b752413"
+pull-stream@^3.2.3, pull-stream@^3.6.9:
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/pull-stream/-/pull-stream-3.6.9.tgz#c774724cd63bc0984c3695f74c819aa02e977320"
 
 pull-traverse@^1.0.3:
   version "1.0.3"
@@ -1922,7 +1913,7 @@ rc@^1.2.7:
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -2037,8 +2028,8 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 secp256k1@^3.3.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.5.0.tgz#677d3b8a8e04e1a5fa381a1ae437c54207b738d0"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.5.2.tgz#f95f952057310722184fe9c914e6b71281f2f2ae"
   dependencies:
     bindings "^1.2.1"
     bip66 "^1.1.3"
@@ -2077,7 +2068,7 @@ set-value@^2.0.0:
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  resolved "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
@@ -2237,7 +2228,7 @@ string_decoder@~1.1.1:
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
 
@@ -2258,15 +2249,15 @@ supports-color@^5.3.0:
     has-flag "^3.0.0"
 
 tar-stream@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
   dependencies:
     bl "^1.0.0"
-    buffer-alloc "^1.1.0"
+    buffer-alloc "^1.2.0"
     end-of-stream "^1.0.0"
     fs-constants "^1.0.0"
     readable-stream "^2.3.0"
-    to-buffer "^1.1.0"
+    to-buffer "^1.1.1"
     xtend "^4.0.0"
 
 tar@^4:
@@ -2300,7 +2291,7 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-buffer@^1.1.0:
+to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
@@ -2411,6 +2402,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+wabt@0.0.13-nightly.20170628:
+  version "0.0.13-nightly.20170628"
+  resolved "https://registry.yarnpkg.com/wabt/-/wabt-0.0.13-nightly.20170628.tgz#58ba4fd34ffe9a8a776205f442050616e3b7e245"
+
 "webcrypto-shim@github:dignifiedquire/webcrypto-shim#master":
   version "0.1.1"
   resolved "https://codeload.github.com/dignifiedquire/webcrypto-shim/tar.gz/190bc9ec341375df6025b17ae12ddb2428ea49c8"
@@ -2429,13 +2424,13 @@ winston-transport@^4.2.0:
     triple-beam "^1.2.0"
 
 winston@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.0.0.tgz#1f0b24a96586798bcf0cd149fb07ed47cb01a1b2"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.1.0.tgz#80724376aef164e024f316100d5b178d78ac5331"
   dependencies:
     async "^2.6.0"
-    diagnostics "^1.0.1"
+    diagnostics "^1.1.1"
     is-stream "^1.1.0"
-    logform "^1.9.0"
+    logform "^1.9.1"
     one-time "0.0.4"
     readable-stream "^2.3.6"
     stack-trace "0.0.x"


### PR DESCRIPTION
This updates the AdChain subgraph to use https://github.com/graphprotocol/graph-ts. The sources are moved to `src/` and the generated code for ABIs is also added to the source tree.

I verified this works with the latest `graph-node`. We'll have to release a new `graph-cli` version with `graph-ts` support before we can merge this though.